### PR TITLE
Add modern responsive WordPress theme

### DIFF
--- a/modern-theme/footer.php
+++ b/modern-theme/footer.php
@@ -1,0 +1,8 @@
+<footer>
+    <div class="container">
+        <p>&copy; <?php echo date('Y'); ?> <?php bloginfo( 'name' ); ?></p>
+    </div>
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/modern-theme/functions.php
+++ b/modern-theme/functions.php
@@ -1,0 +1,6 @@
+<?php
+function mrt_enqueue_scripts() {
+    wp_enqueue_style( 'mrt-style', get_stylesheet_uri(), array(), '1.0.0' );
+}
+add_action( 'wp_enqueue_scripts', 'mrt_enqueue_scripts' );
+

--- a/modern-theme/header.php
+++ b/modern-theme/header.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<header>
+    <div class="container">
+        <h1><a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a></h1>
+    </div>
+</header>

--- a/modern-theme/index.php
+++ b/modern-theme/index.php
@@ -1,0 +1,16 @@
+<?php get_header(); ?>
+<main class="container">
+    <?php if ( have_posts() ) : ?>
+        <?php while ( have_posts() ) : the_post(); ?>
+            <article <?php post_class(); ?>>
+                <h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+                <div class="entry-content">
+                    <?php the_content(); ?>
+                </div>
+            </article>
+        <?php endwhile; ?>
+    <?php else : ?>
+        <p><?php esc_html_e( 'No posts found.', 'modern-responsive-theme' ); ?></p>
+    <?php endif; ?>
+</main>
+<?php get_footer(); ?>

--- a/modern-theme/style.css
+++ b/modern-theme/style.css
@@ -1,0 +1,40 @@
+/*
+Theme Name: Modern Responsive Theme
+Theme URI: https://example.com/modern-responsive-theme
+Author: Example Author
+Author URI: https://example.com
+Description: A modern, mobile responsive WordPress theme.
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: modern-responsive-theme
+Tags: responsive, custom-background, custom-logo, custom-menu
+*/
+
+html, body {
+    margin: 0;
+    padding: 0;
+    font-family: Arial, sans-serif;
+}
+
+header, footer {
+    background: #333;
+    color: white;
+    padding: 1rem;
+}
+
+main {
+    padding: 1rem;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+@media (min-width: 768px) {
+    .flex {
+        display: flex;
+        gap: 1rem;
+    }
+}


### PR DESCRIPTION
## Summary
- add `modern-theme` with standard WP template files
- provide simple responsive CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68586836c4f4832e8d29ce021d266d6a